### PR TITLE
Add chatgpt.com

### DIFF
--- a/foxyproxy.json
+++ b/foxyproxy.json
@@ -163,6 +163,13 @@
     },
     {
       "title": "",
+      "pattern": "*.chatgpt.com",
+      "type": 1,
+      "protocols": 1,
+      "active": true
+    },
+    {
+      "title": "",
       "pattern": "*.cisco.com",
       "type": 1,
       "protocols": 1,

--- a/hosts.txt
+++ b/hosts.txt
@@ -162,6 +162,7 @@ boosteroid.com
 bradyid.com
 cambiumnetworks.com
 certifytheweb.com
+chatgpt.com
 citrix.com
 clevelandclinic.org
 cmems-du.eu


### PR DESCRIPTION
OpenAI now has a redirect from chat.openai.com to chatgpt.com, which has also been blocking Russian IPs.