### PR TITLE
add sbom.sh / comment out apple

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -14,7 +14,7 @@ amd.com
 anthropic.com
 
 # itunes.apple.com/search
-apple.com
+# apple.com
 
 # App installation from marketplace.atlassian.com
 atlassian.com
@@ -539,6 +539,7 @@ resp.app
 reverb.com
 salesforce.com
 samsclub.com
+sbom.sh
 schenker-tech.de
 securitytrails.com
 seekvectorlogo.net


### PR DESCRIPTION
- sbom.sh из россии не работает

- apple в россии работает!, не ограничивает доступ с российских ip адресов, ее наличие в этом списке предлагаю поставить под вопрос или отредактировать более точечно, поскольку завернуть весь apple = это завернуть весь служебный трафик айфонов.