### PR TITLE
Делать исключения для поддомёнов, когда проксирование основного домёна создаёт неудобства

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -257,9 +257,6 @@ paraswap.io
 # builds.parsec.app
 parsec.app
 
-# gateway.pinata.cloud
-pinata.cloud
-
 # support.ptc.com
 ptc.com
 
@@ -497,6 +494,7 @@ g711.org
 gambody.com
 game.co.uk
 gamestop.com
+gateway.pinata.cloud
 genspark.ai
 geospy.ai
 getsafeonline.org


### PR DESCRIPTION
Я активный пользователь pinata.cloud как самого удобного бесплатного загрузчика файлов до ipfs. Вот что я заметил:

1) Gateway.pinata заблокирован в РФ, но pinata.cloud - нет. Сам сервис прекрасно работает из РФ.
2) Gateway.pinata не обладает каким-либо уникальным незаменимым функционалом чтобы ради него проксировать всю пинату. Это просто один из множества мостов до ipfs, в то время как главный из них - ipfs.io/ipfs, в РФ не заблокирован.
3) В hosts уже используются некоторые домёны третьего уровня по типу screamingfrog.co.uk, в основном технического характера.
4) Сам сайт pinata.cloud очень не любит проксирование через VPN. Сейчас у меня не получилось зайти на app.pinata.cloud, которым постоянно пользуюсь, через Тор, на который я подвязал весь хост-лист через Омегу (до этого получалось). А ранее, даже если у меня получалось зайти на app.pinata.cloud через VPN, загрузка файлов на ipfs сбрасывалась из-за маленькой скорости, ибо тамошний загрузчик к ней очень чувствителен, большие файлы (в районе 300 мегабайт) буквально было невозможно загрузить при скорости ниже 40 м/б в секунду (она безрезультатно сбрасывается). Это было протестировано не только с Тором, но и с несколькими нескоростными VPN.

Поэтому я предлагаю для сайтов, которые доказано вызывают подобные трудности, делать исключения, и проксировать домёны третьего уровня. Написанному верить, при желании могу всему вышесказанному предоставить видеодоказательства.