### PR TITLE
Update hosts.txt

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -31,7 +31,9 @@ augmentcode.com
 # accounts.autodesk.com
 # dl.appstreaming.autodesk.com
 # efulfillment.autodesk.com
+# damassets.autodesk.net
 autodesk.com
+autodesk.net
 
 # bits.avcdn.net
 avcdn.net


### PR DESCRIPTION
На этом адресе у них хостятся изображения.

Есть параллельный список (который не так часто обновляют) от re:filter. Там создали issue https://github.com/1andrevich/Re-filter-lists/issues/183 про autodesk где насчитали множество дополнительных домёнов. Я это подробно не проверял, но как минимум без autodesk.net изображения не прогрузились.

**Если не жалко, можно и остальные домёны из issue понадобавлять, но я за достоверность не ручаюсь.**