### PR TITLE
Update process-file.yml

### DIFF
--- a/.github/workflows/process-file.yml
+++ b/.github/workflows/process-file.yml
@@ -16,7 +16,7 @@ jobs:
       
     - name: Process file
       run: |
-        sed '/^[[:space:]]*$/d; /^[[:space:]]*#/d; s/^/*./' hosts.txt | sort > hosts-wildcard.txt
+        sed '/^[[:space:]]*$/d; /^[[:space:]]*#/d; s/^/*/' hosts.txt | sort > hosts-wildcard.txt
     
     - name: Commit and push changes
       run: |
@@ -32,3 +32,4 @@ jobs:
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Изменить формат маски.

В ZeroOmega есть bypass-list, который подчиняется не внутренней логике Омеги, а тому, что написано [на этой страничке](https://developer.chrome.com/docs/extensions/reference/api/proxy#bypass_list). Поэтому в рульлисте (то, что НУЖНО проксировать) "*." обозначает домён и поддомён. А в байпасслисте (то, что НЕ НУЖНО проксировать) "*." обозначает только поддомёны. А вот просто "*" обозначает домёны+поддомёны и там, и там. Поэтому эта точка во-первых лишняя, во-вторых препятствует единообразию.

Прошу потому что человек раздал себе интернет на ноутбук с белосписочного телефона, и там использовал мой Tor Portable. Ему понадобился vk при включённом на весь трафик Торе. "*." не сработал в bypass листе, а "*" сработал. Очень прошу принять pull.