### PR TITLE
Remove apple.com from hosts.txt

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -22,9 +22,6 @@ ansible.com
 # console.anthropic.com
 anthropic.com
 
-# itunes.apple.com/search
-apple.com
-
 # App installation from marketplace.atlassian.com
 atlassian.com
 


### PR DESCRIPTION
Упомянутый в комментариях доступ к itunes.apple.com работает. Проверял разными запросами, например:

```
curl -v 'https://itunes.apple.com/search?term=test'
```

Наличие apple.com в списках замедляет скачивание дистрибутивов ОС и инструментов (десятки гигабайт).
