### PR TITLE
Update hosts.txt removing github.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -122,11 +122,6 @@ fujitsu.com
 # Main domain (pinata.cloud) does not like access from hosters' IP ranges, so add subdomain only
 gateway.pinata.cloud
 
-# Github Copilot, see https://docs.github.com/en/copilot/managing-copilot/managing-github-copilot-in-your-organization/configuring-your-proxy-server-or-firewall-for-copilot
-github.com
-githubcopilot.com
-githubusercontent.com
-
 # packages.gitlab.com/gitlab/gitlab-ee/
 gitlab.com
 


### PR DESCRIPTION
GitHub Copilot работает в России без ограничений. Ранее не пользовался, но для теста зашёл в раздел, потыкал — работает. Страница оплаты для добавления кредитов в аккаунт тоже прогружается.

Статьи в интернете (например, https://dtf.ru/howto/4719223-kak-ispolzovat-github-copilot-v-rossii) информацию, что никакого геоблока (больше?) нет, подтверждают. Единственное, что нужно для работы — зарубежная карта.

В целом добавление github.com в фильтры в любом случае спорно, так как может замедлить доступ даже с быстрым проксированием трафика. 