### PR TITLE
Update hosts.txt removing matrix.org

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -221,9 +221,6 @@ malw.link
 malwarebytes.com
 mbamupdates.com
 
-# matrix-client.matrix.org/_matrix/client/v3/register
-matrix.org
-
 # documentation.meraki.com
 meraki.com
 


### PR DESCRIPTION
Matrix не осуществляет блокировку клиентов из России. Скорее всего, есть какие-то проблемы с CDN у провайдера.

```sh
# curl 'https://matrix-client.matrix.org/_matrix/client/v3/register'
{"errcode":"M_UNRECOGNIZED","error":"Unrecognized request"}
```

Аналогичное возвращается по http и на серверах за границей.