### PR TITLE
Add geo-restricted services blocking RU IPs (AI + misc)

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -90,6 +90,7 @@ cohere.com
 
 # www3.corsair.com
 corsair.com
+coursera.com
 
 # app.deepsource.com
 deepsource.com
@@ -115,6 +116,8 @@ familysearch.org
 # sites.fastspring.com
 # store.fastspring.com
 fastspring.com
+fedex.com
+fireworks.ai
 
 # docs.fortinet.com
 fortinet.com
@@ -234,6 +237,7 @@ metademolab.com
 # copilot.microsoft.com
 # software-static.download.prss.microsoft.com
 microsoft.com
+mistral.ai
 
 # account.mongodb.com
 # cloud.mongodb.com
@@ -270,6 +274,7 @@ openai.com
 
 # ciscobinary.openh264.org
 openh264.org
+opentext.com
 
 # cloud.oracle.com (oraclecloud.com blocks login attempts from Russia)
 oracle.com
@@ -302,6 +307,7 @@ raycast-releases.com
 
 # gold.razer.com
 razer.com
+replicate.com
 
 # support.ruckuswireless.com
 ruckuswireless.com
@@ -338,6 +344,7 @@ summerana.com
 
 # store.supercell.com
 supercell.com
+synopsys.com
 
 # pkgs.tailscale.com
 tailscale.com
@@ -361,6 +368,7 @@ teamviewer.com
 # tiktok.com/@maximusic2019/video/7389281875589729568
 tiktok.com
 tiktokv.com
+together.ai
 ttwstatic.com
 
 # FullHD on Twitch, see https://habr.com/news/922338/
@@ -418,6 +426,7 @@ x.ai
 
 # xboxdesignlab.xbox.com
 xbox.com
+xdaforums.com
 
 # accountmanagement.services.xerox.com/sites/customerportal?hc_login
 # www.support.xerox.com

--- a/hosts.txt
+++ b/hosts.txt
@@ -285,6 +285,7 @@ paraswap.io
 
 # builds.parsec.app
 parsec.app
+pencil.dev
 
 # App installation from store-global.picoxr.com
 picoxr.com


### PR DESCRIPTION
Домены, которые ограничивают доступ с российских резидентных IP (подтверждено — недоступны из РФ). Каждый вставлен в `hosts.txt` по алфавиту.

### AI-сервисы
- `mistral.ai` — Mistral AI
- `replicate.com` — Replicate (ML inference)
- `fireworks.ai` — Fireworks AI
- `together.ai` — Together AI
- `pencil.dev` — Pencil (AI-конструктор интерфейсов)

### Прочее
- `coursera.com` — онлайн-образование
- `fedex.com` — доставка
- `synopsys.com` — EDA/полупроводники (экспортные ограничения)
- `xdaforums.com` — XDA Developers
- `opentext.com` — OpenText

Спасибо за список
